### PR TITLE
add newline before s3.3 DiMLS to fix formatting issue in ietf I-D 00

### DIFF
--- a/draft-xue-mls-decentralized.md
+++ b/draft-xue-mls-decentralized.md
@@ -187,6 +187,7 @@ out-of-order commits.
 DiMLS is defined in {{?I-D.xue-distributed-mls}}.
 
 DiMLS accomodates concurrent actions by
+
 * defining a subset of group operations that are commutative and can be applied
 ou of order
 * using MLS groups as a primitive to represent each local snapshot of the

--- a/draft-xue-mls-decentralized.md
+++ b/draft-xue-mls-decentralized.md
@@ -194,6 +194,17 @@ ou of order
 total group state
 * advancing group state by distributing commits to the sender's local state
 * maintaining causal dependency across MLS groups by exporting shared secrets and
+DiMLS accommodates concurrent actions by:
+
+* defining a subset of group operations that are commutative and can be applied
+out of order
+
+* using MLS groups as a primitive to represent each local snapshot of the
+total group state
+
+* advancing group state by distributing commits to the sender's local state
+
+* maintaining causal dependency across MLS groups by exporting shared secrets and
 importing them as PSK's.
 
 ### Overhead


### PR DESCRIPTION
I think this will improve formatting in https://www.ietf.org/archive/id/draft-xue-mls-decentralized-00.html#section-3.3-2 where the list items are rendered all on one line